### PR TITLE
Allow building projects created from kube-toolkit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ GATEWAY_LINUX_BINARY = $(GATEWAY_BINARY_NAME)-linux
 
 OUTPUT_DIR = bin
 
-VERSION_PACKAGE = github.com/radu-matei/kube-toolkit/pkg/version
+VERSION_PACKAGE = $(shell scripts/gopkg)/pkg/version
 LDFLAGS += -X $(VERSION_PACKAGE).GitCommit=${GIT_COMMIT}
 LDFLAGS += -X $(VERSION_PACKAGE).SemVer=${SEMVER}
 

--- a/scripts/gopath.go
+++ b/scripts/gopath.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+    "fmt"
+    "go/build"
+    "os"
+)
+
+func main() {
+    gopath := os.Getenv("GOPATH")
+    if gopath == "" {
+        gopath = build.Default.GOPATH
+    }
+    fmt.Println(gopath)
+}

--- a/scripts/gopkg
+++ b/scripts/gopkg
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash -e
+
+pwd=$(pwd)
+gosrc=$(go run scripts/gopath.go)/src/
+
+echo ${pwd/$gosrc/}


### PR DESCRIPTION
Without rewriting Makefile.

Partially fix #14